### PR TITLE
[Feature/#22] modal, Alert, Toast 생성

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  allowedDevOrigins: ["192.168.18.3"],
+  allowedDevOrigins: ["192.168.53.170"],
   basePath: "/commute",
 };
 

--- a/src/components/layout/bottom-nav/index.tsx
+++ b/src/components/layout/bottom-nav/index.tsx
@@ -30,7 +30,7 @@ export default function BottomNav() {
                 src={isActive ? item.activeIcon : item.icon}
               />
               <span
-                className={`text-center font-['Noto_Sans_KR'] text-xs leading-4 font-bold ${
+                className={`text-center text-xs leading-4 font-bold ${
                   isActive ? "text-[#3E9DF7]" : "text-[#B7B7B7]"
                 }`}
               >

--- a/src/components/ui/alert/index.tsx
+++ b/src/components/ui/alert/index.tsx
@@ -1,0 +1,106 @@
+import type { HTMLAttributes, ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+interface AlertProps
+  extends Omit<HTMLAttributes<HTMLDivElement>, "children" | "title"> {
+  open?: boolean;
+  title?: ReactNode;
+  message: ReactNode;
+  cancelText?: string;
+  confirmText?: string;
+  onCancel?: () => void;
+  onConfirm?: () => void;
+  panelClassName?: string;
+  titleClassName?: string;
+  contentClassName?: string;
+  buttonGroupClassName?: string;
+  cancelButtonClassName?: string;
+  confirmButtonClassName?: string;
+}
+
+export default function Alert({
+  open = true,
+  title,
+  message,
+  cancelText = "취소",
+  confirmText = "확인",
+  onCancel,
+  onConfirm,
+  className,
+  panelClassName,
+  titleClassName,
+  contentClassName,
+  buttonGroupClassName,
+  cancelButtonClassName,
+  confirmButtonClassName,
+  ...props
+}: AlertProps) {
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <div
+      {...props}
+      className={cn(
+        "fixed inset-y-0 left-1/2 z-[60] flex w-full max-w-150 -translate-x-1/2 items-center justify-center bg-[#444444]/30 px-5",
+        className,
+      )}
+      role="alertdialog"
+      aria-modal="true"
+    >
+      <section
+        className={cn(
+          "w-76.5 max-w-full overflow-hidden rounded-[10px] bg-white shadow-[0_4px_20px_0_#00000040]",
+          panelClassName,
+        )}
+      >
+        <div
+          className={cn(
+            "px-6 py-7 text-center text-[#000000]",
+            contentClassName,
+          )}
+        >
+          {title ? (
+            <h2
+              className={cn(
+                "text-center align-middle text-base leading-none font-bold tracking-[0.21px]",
+                titleClassName,
+              )}
+            >
+              {title}
+            </h2>
+          ) : null}
+
+          <p className="mt-5 text-center align-middle text-sm leading-none font-medium tracking-[0.21px] whitespace-pre-line">
+            {message}
+          </p>
+        </div>
+
+        <div className={cn("flex h-10 min-h-10", buttonGroupClassName)}>
+          <button
+            type="button"
+            className={cn(
+              "flex flex-1 cursor-pointer items-center justify-center bg-[#C6CBD4] text-base leading-6 font-normal tracking-[0.24px] text-white",
+              cancelButtonClassName,
+            )}
+            onClick={onCancel}
+          >
+            {cancelText}
+          </button>
+          <button
+            type="button"
+            className={cn(
+              "flex flex-1 cursor-pointer items-center justify-center bg-[#2076FF] text-base leading-6 font-normal tracking-[0.24px] text-white",
+              confirmButtonClassName,
+            )}
+            onClick={onConfirm}
+          >
+            {confirmText}
+          </button>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -1,2 +1,5 @@
 export { default as Toggle } from "./toggle";
 export { default as Button } from "./button";
+export { default as Alert } from "./alert";
+export { default as Modal } from "./modal";
+export { default as Toast } from "./toast";

--- a/src/components/ui/modal/index.tsx
+++ b/src/components/ui/modal/index.tsx
@@ -1,0 +1,84 @@
+import type { HTMLAttributes, ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+interface ModalProps
+  extends Omit<HTMLAttributes<HTMLDivElement>, "children" | "title"> {
+  open?: boolean;
+  title?: ReactNode;
+  children?: ReactNode;
+  buttonText?: string;
+  onButtonClick?: () => void;
+  panelClassName?: string;
+  titleClassName?: string;
+  contentClassName?: string;
+  buttonClassName?: string;
+}
+
+export default function Modal({
+  open = true,
+  title,
+  children,
+  buttonText = "확인",
+  onButtonClick,
+  className,
+  panelClassName,
+  titleClassName,
+  contentClassName,
+  buttonClassName,
+  ...props
+}: ModalProps) {
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <div
+      {...props}
+      className={cn(
+        "fixed inset-y-0 left-1/2 z-60 flex w-full max-w-150 -translate-x-1/2 items-center justify-center bg-[#444444]/30 px-5",
+        className,
+      )}
+      role="dialog"
+      aria-modal="true"
+    >
+      <section
+        className={cn(
+          "flex max-h-103 w-76.5 max-w-full flex-col overflow-hidden rounded-[10px] bg-white opacity-100 shadow-[0_4px_20px_0_#00000040]",
+          panelClassName,
+        )}
+      >
+        <div
+          className={cn(
+            "modal-scrollbar mr-4 min-h-0 flex-1 overflow-y-auto px-6 py-7 text-[#000000]",
+            contentClassName,
+          )}
+        >
+          {title ? (
+            <h2
+              className={cn(
+                "pl-6 text-center align-middle text-xl leading-none font-bold tracking-[0.21px]",
+                titleClassName,
+              )}
+            >
+              {title}
+            </h2>
+          ) : null}
+
+          {children}
+        </div>
+
+        <button
+          type="button"
+          className={cn(
+            "flex h-14 min-h-14 w-full shrink-0 cursor-pointer items-center justify-center bg-[#2076FF] text-base leading-6 font-normal tracking-[0.24px] text-white",
+            buttonClassName,
+          )}
+          onClick={onButtonClick}
+        >
+          {buttonText}
+        </button>
+      </section>
+    </div>
+  );
+}

--- a/src/components/ui/toast/index.tsx
+++ b/src/components/ui/toast/index.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import type { HTMLAttributes, ReactNode } from "react";
+import { useEffect } from "react";
+
+import { cn } from "@/lib/utils";
+
+interface ToastProps extends Omit<HTMLAttributes<HTMLDivElement>, "children"> {
+  open?: boolean;
+  message: ReactNode;
+  duration?: number;
+  onDismiss?: () => void;
+  panelClassName?: string;
+  contentClassName?: string;
+}
+
+export default function Toast({
+  open = true,
+  message,
+  duration = 2000,
+  onDismiss,
+  className,
+  panelClassName,
+  contentClassName,
+  ...props
+}: ToastProps) {
+  useEffect(() => {
+    if (!open || duration <= 0) {
+      return;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      onDismiss?.();
+    }, duration);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
+  }, [duration, onDismiss, open]);
+
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <div
+      {...props}
+      className={cn(
+        "fixed inset-y-0 left-1/2 z-60 flex w-full max-w-150 -translate-x-1/2 items-center justify-center bg-[#444444]/30 px-5",
+        className,
+      )}
+      role="status"
+      aria-live="polite"
+    >
+      <section
+        className={cn(
+          "w-76.5 max-w-full rounded-[10px] bg-white shadow-[0_4px_20px_0_#00000040]",
+          panelClassName,
+        )}
+      >
+        <div
+          className={cn(
+            "flex min-h-29.25 items-center justify-center px-10 py-11 text-center text-[#000000]",
+            contentClassName,
+          )}
+        >
+          <p className="text-center align-middle text-sm leading-none font-medium tracking-[0.21px]">
+            {message}
+          </p>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/features/home/home-screen/index.tsx
+++ b/src/features/home/home-screen/index.tsx
@@ -2,10 +2,16 @@
 
 import { useState } from "react";
 
-import { Button, Toggle } from "@/components/ui";
+import { Alert, Button, Modal, Toast, Toggle } from "@/components/ui";
+
+type DemoOverlay = "alert" | "modal" | "toast" | null;
 
 export default function HomeScreen() {
   const [isChecked, setIsChecked] = useState(false);
+  const [activeOverlay, setActiveOverlay] = useState<DemoOverlay>(null);
+
+  const closeOverlay = () => setActiveOverlay(null);
+
   return (
     <div className="flex w-full flex-col gap-5 px-5">
       {/* TODO: 버튼 컴포넌트 테스트용 이므로 삭제 예정 */}
@@ -16,6 +22,71 @@ export default function HomeScreen() {
         checked={isChecked}
         onCheckedChange={setIsChecked}
         label="테스트"
+      />
+
+      <div className="grid gap-3">
+        <Button size="lg" onClick={() => setActiveOverlay("alert")}>
+          Alert 예시 보기
+        </Button>
+        <Button size="lg" onClick={() => setActiveOverlay("modal")}>
+          Modal 예시 보기
+        </Button>
+        <Button size="lg" onClick={() => setActiveOverlay("toast")}>
+          Toast 예시 보기
+        </Button>
+      </div>
+
+      <Alert
+        open={activeOverlay === "alert"}
+        title="페이지를 나가시겠습니까?"
+        message={
+          "작성 중인 내용은 저장되지 않으며,\n변경 사항이 모두 사라집니다."
+        }
+        cancelText="나가기"
+        confirmText="계속 작성하기"
+        onCancel={closeOverlay}
+        onConfirm={closeOverlay}
+      />
+
+      <Modal
+        open={activeOverlay === "modal"}
+        title="신청 결과"
+        buttonText="확인"
+        onButtonClick={closeOverlay}
+      >
+        <div className="mt-8">
+          <div>
+            <p className="align-middle text-sm leading-none font-medium tracking-[0.21px] text-[#51A8FF]">
+              신청 성공 6건
+            </p>
+            <ul className="mt-4.75 flex min-h-16.75 w-60.75 flex-col gap-2 text-sm leading-5 font-medium tracking-[0.21px]">
+              <li>4월 6일(월) 13:00 - 14:30 (1.5h)</li>
+              <li>4월 6일(월) 13:00 - 14:30 (1.5h)</li>
+              <li>4월 6일(월) 13:00 - 14:30 (1.5h)</li>
+              <li>4월 6일(월) 13:00 - 14:30 (1.5h)</li>
+              <li>4월 6일(월) 13:00 - 14:30 (1.5h)</li>
+              <li>4월 6일(월) 13:00 - 14:30 (1.5h)</li>
+              <li>4월 6일(월) 13:00 - 14:30 (1.5h)</li>
+            </ul>
+          </div>
+
+          <div className="mt-8">
+            <p className="align-middle text-sm leading-none font-medium tracking-[0.21px] text-[#F24822]">
+              신청 실패 2건
+            </p>
+            <ul className="mt-4.75 flex min-h-16.75 w-60.75 flex-col gap-2 text-sm leading-5 font-medium tracking-[0.21px]">
+              <li>4월 6일(월) 13:00 - 14:30 (1.5h)</li>
+              <li>4월 6일(월) 13:00 - 14:30 (1.5h)</li>
+            </ul>
+          </div>
+        </div>
+      </Modal>
+
+      <Toast
+        open={activeOverlay === "toast"}
+        message="제출이 완료되었습니다."
+        onDismiss={closeOverlay}
+        onClick={closeOverlay}
       />
     </div>
   );

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -25,3 +25,20 @@ a {
   color: inherit;
   text-decoration: none;
 }
+
+/* 스크롤 바를 위한 css 추가 -> modal 창에 사용했습니다. */
+.modal-scrollbar::-webkit-scrollbar {
+  width: 8px;
+}
+
+.modal-scrollbar::-webkit-scrollbar-thumb {
+  background: #8892a6;
+  border-radius: 999px;
+}
+
+.modal-scrollbar::-webkit-scrollbar-track {
+  margin-top: 109px;
+  margin-bottom: 165px;
+  background: #c6cbd4;
+  border-radius: 999px;
+}


### PR DESCRIPTION
## 📌 Related Issues

#22

- close #22

## 📄 Tasks

- modal, alert, toast 구현
- 테스트 컴포넌트 아래 button을 이용하여 예시 컴포넌트 3개를 생성
- toast에서 클릭해서 닫는 기능이 필요하면 onClick 추가하기
- duration={0}을 넘기면 자동 닫힘을 끌 수 있습니다.


## 📷 Screenshot

<img width="624" height="940" alt="1" src="https://github.com/user-attachments/assets/952b50ec-b47f-4dbd-af88-1e0ead5ea3f2" />
<img width="648" height="943" alt="2" src="https://github.com/user-attachments/assets/cc8b73ee-fdf0-4a71-af36-3e9299665f82" />
<img width="674" height="929" alt="3" src="https://github.com/user-attachments/assets/f76b19ac-5916-489d-826b-6d313fa0352f" />

## 🔔 ETC

https://inpa.tistory.com/entry/CSS-%F0%9F%8C%9F-%EC%8A%A4%ED%81%AC%EB%A1%A4-%EB%B0%94Scrollbar-%EA%BE%B8%EB%AF%B8%EA%B8%B0-%EC%86%8D%EC%84%B1-%EC%B4%9D%EC%A0%95%EB%A6%AC
이 글 보고 스크롤 커스톰을 진행하였습니다.
