### PR TITLE
[Feature/#32] update home empty schedule state

### DIFF
--- a/src/features/home/components/date-refresh-button/index.tsx
+++ b/src/features/home/components/date-refresh-button/index.tsx
@@ -34,7 +34,7 @@ export default function DateRefreshButton({
         width={12}
         height={12}
       />
-      <span className="min-w-0 truncate tracking-[0.015em]">
+      <span className="mt-0.5 min-w-0 truncate tracking-[0.015em]">
         {currentDateTime}
       </span>
     </button>

--- a/src/features/home/components/work-schedule-card/index.tsx
+++ b/src/features/home/components/work-schedule-card/index.tsx
@@ -32,33 +32,43 @@ type WorkScheduleCardProps = {
 };
 
 export default function WorkScheduleCard({ schedules }: WorkScheduleCardProps) {
+  const hasSchedules = schedules.length > 0;
+
   return (
-    <div className="mt-4 w-[86vw] max-w-full rounded-[20px] border border-[#DDE3EF] px-5.5 py-3.25">
+    <div className="mt-4 w-[86vw] max-w-full rounded-[20px] border border-[#DDE3EF] px-5.5 py-3">
       <h2 className="text-[11px] leading-5 font-bold text-[#8892A6]">
         오늘의 근무 일정
       </h2>
 
-      <ul className="mt-5 divide-y divide-[#F0F2F8]">
-        {schedules.map((schedule) => (
-          <li
-            className="flex justify-between gap-4 py-2.5 first:pt-0 last:pb-1"
-            key={schedule.id}
-          >
-            <div>
-              <p className="text-[13px] leading-5 font-bold text-[#1A2236]">
-                {schedule.title}
-              </p>
-              <p className="mt-1 text-[11px] leading-4 font-bold text-[#8892A6]">
-                {schedule.time}
-              </p>
-            </div>
-            <Badge
-              text={statusLabel[schedule.status]}
-              variant={statusVariant[schedule.status]}
-            />
-          </li>
-        ))}
-      </ul>
+      {!hasSchedules && (
+        <p className="flex min-h-11.75 items-center justify-center text-[10px] leading-3 tracking-[0.21px] text-[#8892A6]">
+          오늘은 예정된 근무가 없습니다
+        </p>
+      )}
+
+      {hasSchedules && (
+        <ul className="mt-5 divide-y divide-[#F0F2F8]">
+          {schedules.map((schedule) => (
+            <li
+              className="flex justify-between gap-4 py-2.5 first:pt-0 last:pb-1"
+              key={schedule.id}
+            >
+              <div>
+                <p className="text-[13px] leading-5 font-bold text-[#1A2236]">
+                  {schedule.title}
+                </p>
+                <p className="mt-1 text-[11px] leading-4 font-bold text-[#8892A6]">
+                  {schedule.time}
+                </p>
+              </div>
+              <Badge
+                text={statusLabel[schedule.status]}
+                variant={statusVariant[schedule.status]}
+              />
+            </li>
+          ))}
+        </ul>
+      )}
     </div>
   );
 }

--- a/src/features/home/utils/schedule.ts
+++ b/src/features/home/utils/schedule.ts
@@ -20,11 +20,6 @@ const attendanceText = {
     description: "출근 시간이 지났습니다",
     buttonText: "출근하기",
   },
-  empty: {
-    title: "근무 없음",
-    description: "오늘 예정된 근무가 없습니다",
-    buttonText: "출근하기",
-  },
 };
 
 const CLOCK_IN_AVAILABLE_BEFORE_MINUTES = 10;
@@ -136,14 +131,6 @@ const createScheduledAttendanceSummary = ({
   clockInScheduleId,
 });
 
-const createEmptyAttendanceSummary = (): AttendanceSummary => ({
-  status: "scheduled",
-  title: attendanceText.empty.title,
-  description: attendanceText.empty.description,
-  buttonText: attendanceText.empty.buttonText,
-  canClockIn: false,
-});
-
 export const syncSchedulesWithCurrentTime = (
   schedules: BaseWorkSchedule[],
   currentDate: Date,
@@ -163,7 +150,7 @@ export const getAttendanceSummary = (
   currentDate: Date,
   clockedInScheduleId?: number | null,
   clockedInAt?: Date | null,
-): AttendanceSummary => {
+): AttendanceSummary | null => {
   const currentMinutes = getCurrentMinutes(currentDate);
   const clockedInAtMinutes = clockedInAt
     ? getCurrentMinutes(clockedInAt)
@@ -176,7 +163,7 @@ export const getAttendanceSummary = (
     .sort((a, b) => a.startMinutes - b.startMinutes);
 
   if (orderedSchedules.length === 0) {
-    return createEmptyAttendanceSummary();
+    return null;
   }
 
   const completedSchedule = orderedSchedules.find(
@@ -241,7 +228,7 @@ export const getAttendanceSummary = (
   }
 
   return createScheduledAttendanceSummary({
-    startMinutes: orderedSchedules.at(-1)?.startMinutes ?? 0,
+    startMinutes: orderedSchedules.at(-1)?.startMinutes ?? currentMinutes,
     description: attendanceText.expired.description,
   });
 };

--- a/src/features/notification/constants/index.ts
+++ b/src/features/notification/constants/index.ts
@@ -34,5 +34,10 @@ export const mockNotifications: Notification[] = [
 ];
 
 export const mockNotificationSummary: NotificationSummary = {
-  newNotificationCount: 3,
+  isSuccess: true,
+  message: "새 알림 여부를 조회했습니다.",
+  details: {
+    hasNewNotification: true,
+    newNotificationCount: 3,
+  },
 };

--- a/src/features/notification/types/index.ts
+++ b/src/features/notification/types/index.ts
@@ -12,5 +12,10 @@ export type Notification = {
 };
 
 export type NotificationSummary = {
-  newNotificationCount: number;
+  isSuccess: boolean;
+  message: string;
+  details: {
+    hasNewNotification: boolean;
+    newNotificationCount: number;
+  };
 };

--- a/src/screens/alarm/index.tsx
+++ b/src/screens/alarm/index.tsx
@@ -2,6 +2,7 @@ import Image from "next/image";
 import Link from "next/link";
 
 import addTimeIcon from "@/assets/icons/add-time-icon.svg";
+import icLeft from "@/assets/icons/common/ic_left.svg";
 import emptyNotificationIcon from "@/assets/icons/empty-notification-icon.svg";
 import {
   formatNotificationCreatedAt,
@@ -19,12 +20,18 @@ export default function AlarmScreen() {
       <header className="relative mb-10 flex h-15.25 shrink-0 items-center justify-center">
         <Link
           aria-label="홈으로 이동"
-          className="absolute left-2.5 flex items-center justify-center text-[28px] leading-none text-[#111827]"
+          className="absolute left-2.5 flex items-center justify-center"
           href="/"
         >
-          ‹
+          <Image
+            alt=""
+            aria-hidden="true"
+            src={icLeft}
+            width={20}
+            height={20}
+          />
         </Link>
-        <h1 className="text-[16px] leading-6 font-bold">알림</h1>
+        <h1 className="text-[16px] leading-6">알림</h1>
       </header>
 
       {notifications.length > 0 ? (
@@ -74,7 +81,7 @@ export default function AlarmScreen() {
             height={28}
           />
           <p className="mt-2.25 text-[15px] leading-6 font-bold text-[#111827]">
-            새로운 알림이 없습니다.
+            최근 30일 내 알림이 없습니다.
           </p>
         </div>
       )}

--- a/src/screens/home/index.tsx
+++ b/src/screens/home/index.tsx
@@ -43,12 +43,15 @@ export default function HomeScreen() {
     currentDate,
     clockedInScheduleId,
   );
-  const attendance = getAttendanceSummary(
-    schedules,
-    currentDate,
-    clockedInScheduleId,
-    clockedInAt,
-  );
+  const hasSchedules = schedules.length > 0;
+  const attendance = hasSchedules
+    ? getAttendanceSummary(
+        schedules,
+        currentDate,
+        clockedInScheduleId,
+        clockedInAt,
+      )
+    : null;
 
   useEffect(() => {
     const timer = window.setInterval(() => {
@@ -65,7 +68,7 @@ export default function HomeScreen() {
   };
 
   const clockIn = () => {
-    if (attendance.clockInScheduleId == null) {
+    if (attendance?.clockInScheduleId == null) {
       return;
     }
 
@@ -79,7 +82,9 @@ export default function HomeScreen() {
   return (
     <section className="min-h-full w-full bg-white px-6.5 pt-14.5 pb-28 text-[#111827]">
       <HomeHeader
-        newNotificationCount={mockNotificationSummary.newNotificationCount}
+        newNotificationCount={
+          mockNotificationSummary.details.newNotificationCount
+        }
       />
       <HomeGreeting
         teamName={mockHomeData.teamName}
@@ -89,7 +94,9 @@ export default function HomeScreen() {
         currentDateTime={currentDateTime}
         onRefresh={refreshCurrentDateTime}
       />
-      <AttendanceCard attendance={attendance} onClockIn={clockIn} />
+      {attendance && (
+        <AttendanceCard attendance={attendance} onClockIn={clockIn} />
+      )}
       <WorkScheduleCard schedules={schedules} />
     </section>
   );


### PR DESCRIPTION
## 📌 Related Issues

#32

- close #32

## 📄 Tasks

- 홈 화면 오늘의 근무 일정이 없는 경우 빈 상태 문구를 표시하도록 수정
  - `오늘은 예정된 근무가 없습니다`
  - 빈 상태 문구 letter spacing 적용
- 근무 일정이 없을 때 출근 카드가 렌더링되지 않도록 조건부 처리
- 출근 카드용 empty attendance 상태 제거
  - 일정이 없으면 `getAttendanceSummary`가 `null` 반환
- 홈 알림 개수 mock/type을 API 응답 구조에 맞게 수정
  - `details.newNotificationCount` 사용
- 알림함의 홈 이동 아이콘을 텍스트 기호에서 `ic_left.svg`로 교체
- 기타 홈 UI 간격 조정

## 📷 Screenshot

<img width="588" height="850" alt="무제 2" src="https://github.com/user-attachments/assets/111c2143-8843-4cea-8592-387a2206df63" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 예정된 근무가 없을 때 "오늘은 예정된 근무가 없습니다" 메시지 표시

* **UI 개선**
  * 알람 화면 뒤로가기 버튼 아이콘 변경
  * 알림 없음 메시지를 "최근 30일 내 알림이 없습니다"로 업데이트

* **스타일**
  * 날짜 새로고침 버튼 세로 여백 조정
  * 근무 일정 카드 패딩 값 조정

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/konkuk-icteam-student/commute-fe/pull/35?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->