### PR TITLE
[Feature/#38] 근로 시간표 조회 페이지 UI

### DIFF
--- a/src/app/(main)/schedule/page.tsx
+++ b/src/app/(main)/schedule/page.tsx
@@ -2,7 +2,7 @@ import { ScheduleViewScreen } from "@/screens/schedule";
 
 export default function SchedulePage() {
   return (
-    <main className="min-h-screen w-full">
+    <main className="min-h-screen w-full pb-24">
       <ScheduleViewScreen />
     </main>
   );

--- a/src/assets/icons/common/ic_inform_blue.svg
+++ b/src/assets/icons/common/ic_inform_blue.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 14 14" fill="none">
+  <g clip-path="url(#clip0_842_161)">
+    <path d="M6.99882 12.8311C10.2199 12.8311 12.8311 10.2199 12.8311 6.99882C12.8311 3.77772 10.2199 1.1665 6.99882 1.1665C3.77772 1.1665 1.1665 3.77772 1.1665 6.99882C1.1665 10.2199 3.77772 12.8311 6.99882 12.8311Z" stroke="#2563EB" stroke-width="1.16646" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M6.99878 4.66589V6.99882" stroke="#2563EB" stroke-width="1.16646" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M6.99878 9.33167H7.00461" stroke="#2563EB" stroke-width="1.16646" stroke-linecap="round" stroke-linejoin="round"/>
+  </g>
+  <defs>
+    <clipPath id="clip0_842_161">
+      <rect width="13.9976" height="13.9976" fill="white"/>
+    </clipPath>
+  </defs>
+</svg>

--- a/src/features/schedule/components/commute-time-overview/index.tsx
+++ b/src/features/schedule/components/commute-time-overview/index.tsx
@@ -13,11 +13,8 @@ export default function CommuteTimeOverview({
   weeklyTotalHours,
   monthlyTargetHours,
 }: CommuteTimeOverviewProps) {
-  const cappedUsedHours = Math.min(Math.max(usedHours, 0), monthlyTargetHours);
   const monthlyProgressPercent =
-    monthlyTargetHours > 0
-      ? (cappedUsedHours / monthlyTargetHours) * 100
-      : 0;
+    monthlyTargetHours > 0 ? (usedHours / monthlyTargetHours) * 100 : 0;
 
   return (
     <section className="flex w-full flex-col gap-2">
@@ -43,7 +40,7 @@ export default function CommuteTimeOverview({
           role="progressbar"
           aria-valuemin={0}
           aria-valuemax={monthlyTargetHours}
-          aria-valuenow={cappedUsedHours}
+          aria-valuenow={usedHours}
         >
           <div
             className="absolute left-0 h-full rounded-full bg-[#1D4ED8]"

--- a/src/features/schedule/components/commute-time-overview/index.tsx
+++ b/src/features/schedule/components/commute-time-overview/index.tsx
@@ -1,0 +1,56 @@
+interface CommuteTimeOverviewProps {
+  week: number;
+  month: number;
+  usedHours: number;
+  weeklyTotalHours: number;
+  monthlyTargetHours: number;
+}
+
+export default function CommuteTimeOverview({
+  week,
+  month,
+  usedHours,
+  weeklyTotalHours,
+  monthlyTargetHours,
+}: CommuteTimeOverviewProps) {
+  const cappedUsedHours = Math.min(Math.max(usedHours, 0), monthlyTargetHours);
+  const monthlyProgressPercent =
+    monthlyTargetHours > 0
+      ? (cappedUsedHours / monthlyTargetHours) * 100
+      : 0;
+
+  return (
+    <section className="flex w-full flex-col gap-2">
+      <div className="flex flex-row items-center justify-between rounded-[10px] border border-[#DDE3EF] px-3 py-2">
+        <span className="text-xs leading-4.5 font-medium text-[#1A2236]">
+          {week}주차 총 시간
+        </span>
+        <span className="text-xs leading-4.5 font-bold text-[#1D4ED8]">
+          {usedHours} / {weeklyTotalHours}h
+        </span>
+      </div>
+      <div className="flex flex-col items-center gap-2 rounded-[10px] border border-[#DDE3EF] p-3">
+        <div className="flex w-full flex-row items-center justify-between">
+          <span className="text-xs leading-4.5 font-medium text-[#1A2236]">
+            {month}월 전체
+          </span>
+          <span className="text-xs leading-4.5 font-bold text-[#1D4ED8]">
+            {usedHours} / {monthlyTargetHours}h
+          </span>
+        </div>
+        <div
+          className="relative h-1.5 w-full overflow-hidden rounded-full bg-[#EAEAEA]"
+          role="progressbar"
+          aria-valuemin={0}
+          aria-valuemax={monthlyTargetHours}
+          aria-valuenow={cappedUsedHours}
+        >
+          <div
+            className="absolute left-0 h-full rounded-full bg-[#1D4ED8]"
+            style={{ width: `${monthlyProgressPercent}%` }}
+          />
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/features/schedule/components/index.ts
+++ b/src/features/schedule/components/index.ts
@@ -1,3 +1,4 @@
 export { default as ScheduleTable } from "./schedule-table";
 export { default as ScheduleHeader } from "./schedule-header";
 export { default as ScheduleTableHeader } from "./schedule-table-header";
+export { default as ScheduleStatusLegend } from "./schedule-status-legend";

--- a/src/features/schedule/components/index.ts
+++ b/src/features/schedule/components/index.ts
@@ -2,3 +2,4 @@ export { default as ScheduleTable } from "./schedule-table";
 export { default as ScheduleHeader } from "./schedule-header";
 export { default as ScheduleTableHeader } from "./schedule-table-header";
 export { default as ScheduleStatusLegend } from "./schedule-status-legend";
+export { default as CommuteTimeOverview } from "./commute-time-overview";

--- a/src/features/schedule/components/schedule-status-legend/index.tsx
+++ b/src/features/schedule/components/schedule-status-legend/index.tsx
@@ -1,0 +1,87 @@
+import Image from "next/image";
+
+import { cn } from "@/lib/utils";
+import informIcon from "@/assets/icons/common/ic_inform_blue.svg";
+
+import { SLOT_STATUS_CLASS_NAME } from "../../constants";
+
+interface ScheduleStatusLegendProps {
+  isApply?: boolean;
+  minSessionHours: number;
+  weeklyMaxHours: number;
+  monthlyTargetHours: number;
+}
+
+export default function ScheduleStatusLegend({
+  isApply = false,
+  minSessionHours,
+  weeklyMaxHours,
+  monthlyTargetHours,
+}: ScheduleStatusLegendProps) {
+  return (
+    <section className="flex w-full flex-col items-start gap-2 rounded-[10px] bg-[#DBEAFE] px-4 py-2.5">
+      <div className="flex flex-row items-center gap-1.75">
+        <Image
+          className="pt-px pr-px"
+          src={informIcon}
+          alt="inform"
+          aria-hidden="true"
+        />
+        <span className="text-[11px] leading-3 text-[#1A2236]">{`1회 최소 ${minSessionHours}시간 · 주 최대 ${weeklyMaxHours}시간 · 월 목표 ${monthlyTargetHours}시간`}</span>
+      </div>
+
+      <div className="flex flex-row flex-wrap items-center gap-2.5 pl-5">
+        <div className="flex flex-row items-center gap-0.75">
+          <div
+            className={cn(
+              "h-2.5 w-2.5 rounded-full",
+              SLOT_STATUS_CLASS_NAME.EMPTY,
+            )}
+          />
+          <span className="text-[10px] text-[#1A2236]">신청 가능</span>
+        </div>
+        <div className="flex flex-row items-center gap-0.75">
+          <div
+            className={cn(
+              "h-2.5 w-2.5 rounded-full",
+              SLOT_STATUS_CLASS_NAME.UNAVAILABLE,
+            )}
+          />
+          <span className="text-[10px] text-[#1A2236]">신청 불가</span>
+        </div>
+        {!isApply && (
+          <>
+            <div className="flex flex-row items-center gap-0.75">
+              <div
+                className={cn(
+                  "h-2.5 w-2.5 rounded-full",
+                  SLOT_STATUS_CLASS_NAME.PENDING_ADD,
+                )}
+              />
+              <span className="text-[10px] text-[#1A2236]">추가 예정</span>
+            </div>
+            <div className="flex flex-row items-center gap-0.75">
+              <div
+                className={cn(
+                  "h-2.5 w-2.5 rounded-full",
+                  SLOT_STATUS_CLASS_NAME.PENDING_DELETE,
+                )}
+              />
+              <span className="text-[10px] text-[#1A2236]">삭제 예정</span>
+            </div>
+          </>
+        )}
+
+        <div className="flex flex-row items-center gap-0.75">
+          <div
+            className={cn(
+              "h-2.5 w-2.5 rounded-full",
+              SLOT_STATUS_CLASS_NAME.MY_SCHEDULE,
+            )}
+          />
+          <span className="text-[10px] text-[#1A2236]">신청 완료</span>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/features/schedule/components/schedule-status-legend/index.tsx
+++ b/src/features/schedule/components/schedule-status-legend/index.tsx
@@ -5,6 +5,31 @@ import informIcon from "@/assets/icons/common/ic_inform_blue.svg";
 
 import { SLOT_STATUS_CLASS_NAME } from "../../constants";
 
+const SCHEDULE_STATUS_LEGEND_ITEMS = [
+  {
+    label: "신청 가능",
+    className: SLOT_STATUS_CLASS_NAME.EMPTY,
+  },
+  {
+    label: "신청 불가",
+    className: SLOT_STATUS_CLASS_NAME.UNAVAILABLE,
+  },
+  {
+    label: "추가 예정",
+    className: SLOT_STATUS_CLASS_NAME.PENDING_ADD,
+    hiddenOnApply: true,
+  },
+  {
+    label: "삭제 예정",
+    className: SLOT_STATUS_CLASS_NAME.PENDING_DELETE,
+    hiddenOnApply: true,
+  },
+  {
+    label: "신청 완료",
+    className: SLOT_STATUS_CLASS_NAME.MY_SCHEDULE,
+  },
+];
+
 interface ScheduleStatusLegendProps {
   isApply?: boolean;
   minSessionHours: number;
@@ -31,56 +56,14 @@ export default function ScheduleStatusLegend({
       </div>
 
       <div className="flex flex-row flex-wrap items-center gap-2.5 pl-5">
-        <div className="flex flex-row items-center gap-0.75">
-          <div
-            className={cn(
-              "h-2.5 w-2.5 rounded-full",
-              SLOT_STATUS_CLASS_NAME.EMPTY,
-            )}
-          />
-          <span className="text-[10px] text-[#1A2236]">신청 가능</span>
-        </div>
-        <div className="flex flex-row items-center gap-0.75">
-          <div
-            className={cn(
-              "h-2.5 w-2.5 rounded-full",
-              SLOT_STATUS_CLASS_NAME.UNAVAILABLE,
-            )}
-          />
-          <span className="text-[10px] text-[#1A2236]">신청 불가</span>
-        </div>
-        {!isApply && (
-          <>
-            <div className="flex flex-row items-center gap-0.75">
-              <div
-                className={cn(
-                  "h-2.5 w-2.5 rounded-full",
-                  SLOT_STATUS_CLASS_NAME.PENDING_ADD,
-                )}
-              />
-              <span className="text-[10px] text-[#1A2236]">추가 예정</span>
-            </div>
-            <div className="flex flex-row items-center gap-0.75">
-              <div
-                className={cn(
-                  "h-2.5 w-2.5 rounded-full",
-                  SLOT_STATUS_CLASS_NAME.PENDING_DELETE,
-                )}
-              />
-              <span className="text-[10px] text-[#1A2236]">삭제 예정</span>
-            </div>
-          </>
-        )}
-
-        <div className="flex flex-row items-center gap-0.75">
-          <div
-            className={cn(
-              "h-2.5 w-2.5 rounded-full",
-              SLOT_STATUS_CLASS_NAME.MY_SCHEDULE,
-            )}
-          />
-          <span className="text-[10px] text-[#1A2236]">신청 완료</span>
-        </div>
+        {SCHEDULE_STATUS_LEGEND_ITEMS.filter(
+          ({ hiddenOnApply }) => !(isApply && hiddenOnApply),
+        ).map(({ label, className }) => (
+          <div key={label} className="flex flex-row items-center gap-0.75">
+            <div className={cn("h-2.5 w-2.5 rounded-full", className)} />
+            <span className="text-[10px] text-[#1A2236]">{label}</span>
+          </div>
+        ))}
       </div>
     </section>
   );

--- a/src/features/schedule/components/schedule-status-legend/index.tsx
+++ b/src/features/schedule/components/schedule-status-legend/index.tsx
@@ -49,7 +49,7 @@ export default function ScheduleStatusLegend({
         <Image
           className="pt-px pr-px"
           src={informIcon}
-          alt="inform"
+          alt=""
           aria-hidden="true"
         />
         <span className="text-[11px] leading-3 text-[#1A2236]">{`1회 최소 ${minSessionHours}시간 · 주 최대 ${weeklyMaxHours}시간 · 월 목표 ${monthlyTargetHours}시간`}</span>

--- a/src/features/schedule/constants/slot.ts
+++ b/src/features/schedule/constants/slot.ts
@@ -4,8 +4,8 @@ export const SLOTS_PER_DAY = 18; // 09:00 ~ 18:00 까지. 일주일은 총 90개
 
 export const SLOT_STATUS_CLASS_NAME: Record<ScheduleSlotStatus, string> = {
   MY_SCHEDULE: "bg-[#51A8FF]",
-  PENDING_DELETE: "border border-[#DDD9D9] bg-[#FFF9EA]",
-  PENDING_ADD: "border border-[#DDD9D9] bg-[#EDF5FF]",
+  PENDING_DELETE: "border border-[#FFD280] bg-[#FFF9EA]",
+  PENDING_ADD: "border border-[#769EF3] bg-[#EDF5FF]",
   UNAVAILABLE: "border border-[#DDD9D9] bg-[rgba(107,114,128,0.11)]",
   EMPTY: "border border-[#DDD9D9] bg-white",
 };
@@ -14,6 +14,6 @@ export const SLOT_REQUEST_EDIT_CLASS_NAME: Record<
   ScheduleRequestEditStatus,
   string
 > = {
-  REQUEST_ADD: "border border-[#1D4ED8] bg-[#DBEAFE]",
-  REQUEST_DELETE: "border border-[#FD7171] bg-[#FFF4D7]",
+  REQUEST_ADD: "border-2 border-[#1D4ED8] bg-[#DBEAFE]",
+  REQUEST_DELETE: "border-2 border-[#FD7171] bg-[#FFF4D7]",
 };

--- a/src/features/schedule/index.ts
+++ b/src/features/schedule/index.ts
@@ -3,6 +3,7 @@ export {
   ScheduleHeader,
   ScheduleTableHeader,
   ScheduleStatusLegend,
+  CommuteTimeOverview,
 } from "./components";
 
 export { DUMMY_GET_SCHEDULE, DUMMY_NEXT_MONTH_SCHEDULE } from "./constants";

--- a/src/features/schedule/index.ts
+++ b/src/features/schedule/index.ts
@@ -2,6 +2,7 @@ export {
   ScheduleTable,
   ScheduleHeader,
   ScheduleTableHeader,
+  ScheduleStatusLegend,
 } from "./components";
 
 export { DUMMY_GET_SCHEDULE, DUMMY_NEXT_MONTH_SCHEDULE } from "./constants";

--- a/src/screens/schedule/schedule-view/index.tsx
+++ b/src/screens/schedule/schedule-view/index.tsx
@@ -7,6 +7,7 @@ import {
   ScheduleTable,
   DUMMY_GET_SCHEDULE,
   ScheduleStatusLegend,
+  CommuteTimeOverview,
 } from "@/features/schedule";
 import { getMonthWeekOfDate, shiftDateByWeeks } from "@/lib/date-formatter";
 
@@ -37,6 +38,15 @@ export default function ScheduleViewScreen() {
         <ScheduleStatusLegend
           minSessionHours={1}
           weeklyMaxHours={13}
+          monthlyTargetHours={27}
+        />
+      </div>
+      <div className="flex flex-col gap-2">
+        <CommuteTimeOverview
+          week={1}
+          month={6}
+          usedHours={3}
+          weeklyTotalHours={7}
           monthlyTargetHours={27}
         />
       </div>

--- a/src/screens/schedule/schedule-view/index.tsx
+++ b/src/screens/schedule/schedule-view/index.tsx
@@ -6,6 +6,7 @@ import {
   ScheduleHeader,
   ScheduleTable,
   DUMMY_GET_SCHEDULE,
+  ScheduleStatusLegend,
 } from "@/features/schedule";
 import { getMonthWeekOfDate, shiftDateByWeeks } from "@/lib/date-formatter";
 
@@ -22,16 +23,23 @@ export default function ScheduleViewScreen() {
   };
 
   return (
-    <div className="flex w-full flex-col gap-5 px-3 py-4">
+    <div className="flex w-full flex-col gap-4 px-3 py-4">
       <ScheduleHeader year={year} month={month} />
-      <ScheduleTable
-        year={year}
-        month={month}
-        week={week}
-        scheduleData={DUMMY_GET_SCHEDULE}
-        handlePrevWeek={handlePrevWeek}
-        handleNextWeek={handleNextWeek}
-      />
+      <div className="flex flex-col gap-2">
+        <ScheduleTable
+          year={year}
+          month={month}
+          week={week}
+          scheduleData={DUMMY_GET_SCHEDULE}
+          handlePrevWeek={handlePrevWeek}
+          handleNextWeek={handleNextWeek}
+        />
+        <ScheduleStatusLegend
+          minSessionHours={1}
+          weeklyMaxHours={13}
+          monthlyTargetHours={27}
+        />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## 📌 Related Issues

- close #38 

## 📄 Tasks

- ScheduleStatusLegend 컴포넌트 구현
- CommuteTimeOverview 섹션 컴포넌트 구현

TODO
- 처리내역 부분은 추후 서버 api 이해 및 논의 추가 예정



## 📷 Screenshot

<img width="466" height="825" alt="image" src="https://github.com/user-attachments/assets/a3c0d266-e610-4ca3-9a7c-8d3c48b6cdaf" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **신규 기능**
  * 스케줄 상태 범례 UI 추가 (신청 가능/불가 및 대기 상태 표시)
  * 주차 및 월간 통근 시간 사용 현황을 시각화하는 요약 UI 추가

* **스타일**
  * 예정된 추가/삭제 항목의 테두리 색상 및 강도 개선
  * 스케줄 페이지 하단 여백 조정

<!-- end of auto-generated comment: release notes by coderabbit.ai -->