### PR TITLE
[Feature/#37] 근로시간 신청 페이지 UI 구현

### DIFF
--- a/src/features/schedule/components/index.ts
+++ b/src/features/schedule/components/index.ts
@@ -4,3 +4,4 @@ export { default as ScheduleTableHeader } from "./schedule-table-header";
 export { default as ScheduleStatusLegend } from "./schedule-status-legend";
 export { default as ScheduleChangeHistoryPreview } from "./schedule-change-history-preview";
 export { default as WorkingHoursCard } from "./working-hours-card";
+export { default as ScheduleChangeList } from "./schedule-change-item";

--- a/src/features/schedule/components/schedule-change-item/index.tsx
+++ b/src/features/schedule/components/schedule-change-item/index.tsx
@@ -14,7 +14,17 @@ interface ScheduleChangeListProps {
 const formatRequestSlotLabel = (
   slot: ScheduleApplyPayload["deleteSlots"][number],
 ) => {
+  const datePattern = /^\d{4}-\d{2}-\d{2}$/;
+  if (!datePattern.test(slot.date)) {
+    console.error(`Invalid date format: ${slot.date}`);
+    return "잘못된 날짜 형식";
+  }
+
   const [, month, day] = slot.date.split("-").map(Number);
+
+  if (isNaN(month) || isNaN(day)) {
+    return "날짜 파싱 실패";
+  }
 
   return `${month}월 ${day}일 ${slot.start}-${slot.end} (${getSlotTimesTotalHours([slot])}h)`;
 };

--- a/src/features/schedule/components/schedule-change-item/index.tsx
+++ b/src/features/schedule/components/schedule-change-item/index.tsx
@@ -1,0 +1,46 @@
+import Image from "next/image";
+
+import { ScheduleApplyPayload, ScheduleSlotTime } from "../../types";
+import { getSlotTimesTotalHours } from "../../utils";
+
+import addTimeIcon from "@/assets/icons/common/ic_add_time.svg";
+import deleteTimeIcon from "@/assets/icons/common/ic_delete_time.svg";
+
+interface ScheduleChangeListProps {
+  isAdd?: boolean;
+  changeItems: ScheduleSlotTime[];
+}
+
+const formatRequestSlotLabel = (
+  slot: ScheduleApplyPayload["deleteSlots"][number],
+) => {
+  const [, month, day] = slot.date.split("-").map(Number);
+
+  return `${month}월 ${day}일 ${slot.start}-${slot.end} (${getSlotTimesTotalHours([slot])}h)`;
+};
+
+export default function ScheduleChangeList({
+  isAdd = true,
+  changeItems,
+}: ScheduleChangeListProps) {
+  return (
+    changeItems.length > 0 && (
+      <div className="flex max-h-21 flex-col gap-1.5 overflow-scroll px-3">
+        {changeItems.map((item) => (
+          <div
+            key={`${item.date}-${item.start}-${item.end}`}
+            className="flex flex-row items-center gap-1.5"
+          >
+            <Image
+              alt={isAdd ? "추가" : "삭제"}
+              src={isAdd ? addTimeIcon : deleteTimeIcon}
+            />
+            <span className="text-xs text-[#09121C]">
+              {formatRequestSlotLabel(item)}
+            </span>
+          </div>
+        ))}
+      </div>
+    )
+  );
+}

--- a/src/features/schedule/components/working-hours-card/index.tsx
+++ b/src/features/schedule/components/working-hours-card/index.tsx
@@ -33,7 +33,11 @@ export default function WorkingHoursCard({
           {label}
         </span>
         <span className="text-xs leading-4.5 font-bold text-[#C6CBD4]">
-          <span className={isRed ? "text-[#FD7171]" : "text-[#1D4ED8]"}>
+          <span
+            className={
+              isRed || isOverflow ? "text-[#FD7171]" : "text-[#1D4ED8]"
+            }
+          >
             {hours}
             {maxHours === undefined && "h"}
           </span>
@@ -49,7 +53,10 @@ export default function WorkingHoursCard({
           aria-valuenow={hours}
         >
           <div
-            className="absolute left-0 h-full rounded-full bg-[#1D4ED8]"
+            className={cn(
+              "absolute left-0 h-full rounded-full bg-[#1D4ED8]",
+              isOverflow && "bg-[#FD7171]",
+            )}
             style={{ width: `${progressPercent}%` }}
           />
         </div>

--- a/src/features/schedule/index.ts
+++ b/src/features/schedule/index.ts
@@ -5,6 +5,7 @@ export {
   ScheduleStatusLegend,
   ScheduleChangeHistoryPreview,
   WorkingHoursCard,
+  ScheduleChangeList,
 } from "./components";
 
 export {
@@ -24,6 +25,7 @@ export {
   getRequestEditSlotStatus,
   getRequestEditSlotDisabled,
   getSlotTimesTotalHours,
+  getSlotTimesTotalHoursOnWeek,
   isBeforeDate,
   mergeContinuousSlotTimes,
   toggleRequestEditSlotChange,

--- a/src/features/schedule/utils/apply-change.test.ts
+++ b/src/features/schedule/utils/apply-change.test.ts
@@ -10,10 +10,13 @@ const {
   getRequestEditSlotStatus,
   getRequestEditSlotDisabled,
   getSlotTimesTotalHours,
+  getSlotTimesTotalHoursOnWeek,
   mergeContinuousSlotTimes,
   toggleRequestEditSlotChange,
   toggleApplySlotChange,
-} = (await import(new URL("./index.ts", import.meta.url).href)) as typeof import("./index");
+} = (await import(
+  new URL("./index.ts", import.meta.url).href
+)) as typeof import("./index");
 
 const basePayload: ScheduleApplyPayload = {
   deleteSlots: [],
@@ -103,7 +106,10 @@ describe("toggleApplySlotChange", () => {
 
 describe("toggleRequestEditSlotChange", () => {
   it("adds existing slots to deleteSlots and removes them on second click", () => {
-    const addedToDelete = toggleRequestEditSlotChange(basePayload, myScheduleSlot);
+    const addedToDelete = toggleRequestEditSlotChange(
+      basePayload,
+      myScheduleSlot,
+    );
 
     assert.deepEqual(addedToDelete.deleteSlots, [
       { date: "2026-04-06", start: "13:00", end: "14:30" },
@@ -153,10 +159,13 @@ describe("toggleRequestEditSlotChange", () => {
         addSlots: [],
       },
     );
-    assert.deepEqual(toggleRequestEditSlotChange(basePayload, unavailableSlot), {
-      deleteSlots: [],
-      addSlots: [],
-    });
+    assert.deepEqual(
+      toggleRequestEditSlotChange(basePayload, unavailableSlot),
+      {
+        deleteSlots: [],
+        addSlots: [],
+      },
+    );
   });
 
   it("does not add empty slots when the current count is already full", () => {
@@ -246,7 +255,10 @@ describe("getRequestEditSlotStatus", () => {
       emptySlot,
     );
 
-    assert.equal(getRequestEditSlotStatus(myScheduleSlot, payload), "REQUEST_DELETE");
+    assert.equal(
+      getRequestEditSlotStatus(myScheduleSlot, payload),
+      "REQUEST_DELETE",
+    );
     assert.equal(getRequestEditSlotStatus(emptySlot, payload), "REQUEST_ADD");
   });
 });
@@ -298,6 +310,22 @@ describe("getSlotTimesTotalHours", () => {
         { date: "2026-04-06", start: "13:00", end: "14:30" },
         { date: "2026-04-09", start: "09:30", end: "10:00" },
       ]),
+      2,
+    );
+  });
+});
+
+describe("getSlotTimesTotalHoursOnWeek", () => {
+  it("returns total duration only for slots on the provided dates", () => {
+    assert.equal(
+      getSlotTimesTotalHoursOnWeek(
+        [
+          { date: "2026-04-06", start: "13:00", end: "14:30" },
+          { date: "2026-04-09", start: "09:30", end: "10:00" },
+          { date: "2026-04-13", start: "13:00", end: "14:30" },
+        ],
+        ["2026-04-06", "2026-04-09"],
+      ),
       2,
     );
   });
@@ -355,12 +383,8 @@ describe("getMergedApplyPayload", () => {
         ],
       }),
       {
-        deleteSlots: [
-          { date: "2026-04-06", start: "13:00", end: "14:00" },
-        ],
-        addSlots: [
-          { date: "2026-04-09", start: "13:30", end: "14:30" },
-        ],
+        deleteSlots: [{ date: "2026-04-06", start: "13:00", end: "14:00" }],
+        addSlots: [{ date: "2026-04-09", start: "13:30", end: "14:30" }],
       },
     );
   });

--- a/src/features/schedule/utils/index.ts
+++ b/src/features/schedule/utils/index.ts
@@ -132,6 +132,15 @@ export const getSlotTimesTotalHours = (slots: ScheduleSlotTime[]) =>
     0,
   ) / 60;
 
+export const getSlotTimesTotalHoursOnWeek = (
+  slots: ScheduleSlotTime[],
+  dates: string[],
+) => {
+  const dateSet = new Set(dates);
+
+  return getSlotTimesTotalHours(slots.filter((slot) => dateSet.has(slot.date)));
+};
+
 export const getRequestEditSlotDisabled = (
   slot: ScheduleSlot,
   payload: ScheduleApplyPayload,

--- a/src/screens/schedule/schedule-apply/index.tsx
+++ b/src/screens/schedule/schedule-apply/index.tsx
@@ -13,9 +13,27 @@ import {
   getApplySlotStatus,
   getMergedApplyPayload,
   toggleApplySlotChange,
+  ScheduleStatusLegend,
+  WorkingHoursCard,
+  getSlotTimesTotalHours,
+  getSlotTimesTotalHoursOnWeek,
+  getDateStringFromDateLabel,
+  ScheduleChangeList,
 } from "@/features/schedule";
-import { getMonthWeekOfDate, shiftDateByWeeks } from "@/lib/date-formatter";
+import {
+  getMonthWeekOfDate,
+  getWeekdaysOfMonthWeek,
+  shiftDateByWeeks,
+} from "@/lib/date-formatter";
 import { Button } from "@/components/ui";
+
+// TODO: 추후 서버에서 받아올 값
+const MIN_SESSION_HOURS = 1;
+const MAX_WEEK_HOURS = 13;
+const MAX_MONTH_HOURS = 27;
+
+const WEEK_TOTAL_HOURS = 12;
+const MONTH_TOTAL_HOURS = 25;
 
 export default function ScheduleApplyScreen() {
   const [selectedDate, setSelectedDate] = useState(getFirstDateOfNextMonth);
@@ -31,6 +49,30 @@ export default function ScheduleApplyScreen() {
     year !== prevWeekMonth.year || month !== prevWeekMonth.month;
   const isNextWeekDisabled =
     year !== nextWeekMonth.year || month !== nextWeekMonth.month;
+
+  const addRequestHours = getSlotTimesTotalHours(applyPayload.addSlots);
+  const deleteRequestHours = getSlotTimesTotalHours(applyPayload.deleteSlots);
+  const currentWeekDates = getWeekdaysOfMonthWeek(year, month, week).map(
+    ({ date }) => getDateStringFromDateLabel(year, date),
+  );
+  const weeklyAddRequestHours = getSlotTimesTotalHoursOnWeek(
+    applyPayload.addSlots,
+    currentWeekDates,
+  );
+  const weeklyDeleteRequestHours = getSlotTimesTotalHoursOnWeek(
+    applyPayload.deleteSlots,
+    currentWeekDates,
+  );
+
+  const weekTotalTimeAfterApply =
+    WEEK_TOTAL_HOURS + weeklyAddRequestHours - weeklyDeleteRequestHours;
+  const monthTotalTimeAfterApply =
+    MONTH_TOTAL_HOURS + addRequestHours - deleteRequestHours;
+
+  const buttonDisabled =
+    (deleteRequestHours === 0 && addRequestHours === 0) ||
+    weekTotalTimeAfterApply > MAX_WEEK_HOURS ||
+    monthTotalTimeAfterApply > MAX_MONTH_HOURS;
 
   const handlePrevWeek = () => {
     setSelectedDate((currentDate) => {
@@ -79,32 +121,70 @@ export default function ScheduleApplyScreen() {
   return (
     <div className="flex w-full flex-col gap-5 px-3 py-4">
       <ScheduleHeader mode="apply" year={year} month={month} />
-      <ScheduleTable
-        type="apply"
-        year={year}
-        month={month}
-        week={week}
-        scheduleData={DUMMY_NEXT_MONTH_SCHEDULE}
-        isPrevWeekDisabled={isPrevWeekDisabled}
-        isNextWeekDisabled={isNextWeekDisabled}
-        handlePrevWeek={handlePrevWeek}
-        handleNextWeek={handleNextWeek}
-        getSlotCurrentCount={(slot) =>
-          getApplySlotCurrentCount(slot, applyPayload)
-        }
-        getSlotStatus={(slot) => getApplySlotStatus(slot, applyPayload)}
-        onSlotClick={handleSlotClick}
-      />
+      <div className="flex flex-col gap-2">
+        <ScheduleTable
+          type="apply"
+          year={year}
+          month={month}
+          week={week}
+          scheduleData={DUMMY_NEXT_MONTH_SCHEDULE}
+          isPrevWeekDisabled={isPrevWeekDisabled}
+          isNextWeekDisabled={isNextWeekDisabled}
+          handlePrevWeek={handlePrevWeek}
+          handleNextWeek={handleNextWeek}
+          getSlotCurrentCount={(slot) =>
+            getApplySlotCurrentCount(slot, applyPayload)
+          }
+          getSlotStatus={(slot) => getApplySlotStatus(slot, applyPayload)}
+          onSlotClick={handleSlotClick}
+        />
+        <ScheduleStatusLegend
+          isApply
+          minSessionHours={MIN_SESSION_HOURS}
+          weeklyMaxHours={MAX_WEEK_HOURS}
+          monthlyTargetHours={MAX_MONTH_HOURS}
+        />
+      </div>
+      <div className="flex flex-col gap-3">
+        <div className="flex flex-col gap-2">
+          <WorkingHoursCard label="근무 신청" hours={addRequestHours} />
+          <ScheduleChangeList
+            changeItems={getMergedApplyPayload(applyPayload).addSlots}
+          />
+        </div>
+        <div className="flex flex-col gap-2">
+          <WorkingHoursCard
+            label="근무 삭제"
+            hours={deleteRequestHours}
+            isRed
+          />
+          <ScheduleChangeList
+            isAdd={false}
+            changeItems={getMergedApplyPayload(applyPayload).deleteSlots}
+          />
+        </div>
+        <WorkingHoursCard
+          label={`${week}주차 총 시간`}
+          hours={weekTotalTimeAfterApply}
+          maxHours={MAX_WEEK_HOURS}
+          isOverflow={weekTotalTimeAfterApply > MAX_WEEK_HOURS}
+        />
+        <WorkingHoursCard
+          label={`${month}월 전체`}
+          hours={monthTotalTimeAfterApply}
+          maxHours={MAX_MONTH_HOURS}
+          withProgressBar
+          isOverflow={monthTotalTimeAfterApply > MAX_MONTH_HOURS}
+        />
+      </div>
+
       {/* TODO: 아래 버튼은 추후에 제대로 구현 예정. 현재는 테스트 버튼 */}
       <Button
         size="lg"
         onClick={() => {
-          console.log("각각의 slot : ", {
-            deleteSlots: applyPayload.deleteSlots,
-            addSlots: applyPayload.addSlots,
-          });
           console.log("slot 병합 이후 : ", getMergedApplyPayload(applyPayload));
         }}
+        disabled={buttonDisabled}
       >
         저장하기
       </Button>

--- a/src/screens/schedule/schedule-edit/index.tsx
+++ b/src/screens/schedule/schedule-edit/index.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState } from "react";
-import Image from "next/image";
 
 import {
   DUMMY_GET_SCHEDULE,
@@ -16,28 +15,22 @@ import {
   getSlotTimesTotalHours,
   ScheduleStatusLegend,
   WorkingHoursCard,
+  ScheduleChangeList,
 } from "@/features/schedule";
 import { SLOT_REQUEST_EDIT_CLASS_NAME } from "@/features/schedule/constants";
 import { getMonthWeekOfDate, shiftDateByWeeks } from "@/lib/date-formatter";
 import { Button } from "@/components/ui";
-import addTimeIcon from "@/assets/icons/common/ic_add_time.svg";
-import deleteTimeIcon from "@/assets/icons/common/ic_delete_time.svg";
 
 // TODO: 추후 서버에서 받아올 값
+const MIN_SESSION_HOURS = 1;
+const MAX_WEEK_HOURS = 13;
+
 const WEEK_HOURS = 2;
 const MONTH_TOTAL_HOURS = 26;
 const MAX_MONTH_HOURS = 27;
 
 const getAbleToAddHours = (deleteRequestHours: number) =>
   MAX_MONTH_HOURS - MONTH_TOTAL_HOURS + deleteRequestHours;
-
-const formatRequestSlotLabel = (
-  slot: ScheduleApplyPayload["deleteSlots"][number],
-) => {
-  const [, month, day] = slot.date.split("-").map(Number);
-
-  return `${month}월 ${day}일 ${slot.start}-${slot.end} (${getSlotTimesTotalHours([slot])}h)`;
-};
 
 export default function ScheduleEditScreen() {
   const today = new Date();
@@ -152,9 +145,9 @@ export default function ScheduleEditScreen() {
           unavailableBeforeDate={today}
         />
         <ScheduleStatusLegend
-          minSessionHours={1}
-          weeklyMaxHours={13}
-          monthlyTargetHours={27}
+          minSessionHours={MIN_SESSION_HOURS}
+          weeklyMaxHours={MAX_WEEK_HOURS}
+          monthlyTargetHours={MAX_MONTH_HOURS}
         />
       </div>
       <div className="flex flex-col gap-2">
@@ -172,19 +165,10 @@ export default function ScheduleEditScreen() {
           isRed
           isOverflow={deleteRequestHours > MONTH_TOTAL_HOURS}
         />
-        <div className="flex flex-col gap-1.5 px-3">
-          {getMergedApplyPayload(editPayload).deleteSlots.map((item) => (
-            <div
-              key={`${item.date}-${item.start}-${item.end}`}
-              className="flex flex-row items-center gap-1.5"
-            >
-              <Image alt="삭제" src={deleteTimeIcon} />
-              <span className="text-xs text-[#09121C]">
-                {formatRequestSlotLabel(item)}
-              </span>
-            </div>
-          ))}
-        </div>
+        <ScheduleChangeList
+          isAdd={false}
+          changeItems={getMergedApplyPayload(editPayload).deleteSlots}
+        />
 
         <WorkingHoursCard
           label="추가 근무 신청"
@@ -192,19 +176,9 @@ export default function ScheduleEditScreen() {
           maxHours={ableToAddHours}
           isOverflow={addRequestHours > ableToAddHours}
         />
-        <div className="flex flex-col gap-1.5 px-3">
-          {getMergedApplyPayload(editPayload).addSlots.map((item) => (
-            <div
-              key={`${item.date}-${item.start}-${item.end}`}
-              className="flex flex-row items-center gap-1.5"
-            >
-              <Image alt="추가" src={addTimeIcon} />
-              <span className="text-xs text-[#09121C]">
-                {formatRequestSlotLabel(item)}
-              </span>
-            </div>
-          ))}
-        </div>
+        <ScheduleChangeList
+          changeItems={getMergedApplyPayload(editPayload).addSlots}
+        />
 
         <section className="flex w-full flex-col gap-2 rounded-[10px] border border-[#DDE3EF] px-3 py-2">
           <span className="text-xs leading-4.5 font-medium text-[#1A2236]">

--- a/src/screens/schedule/schedule-view/index.tsx
+++ b/src/screens/schedule/schedule-view/index.tsx
@@ -14,6 +14,10 @@ import {
 import { getMonthWeekOfDate, shiftDateByWeeks } from "@/lib/date-formatter";
 
 // TODO: 추후 서버에서 받아올 값
+const MIN_SESSION_HOURS = 1;
+const MAX_WEEK_HOURS = 13;
+const MAX_MONTH_HOURS = 27;
+
 const WEEK_HOURS = 4;
 const WEEK_TOTAL_HOURS = 7;
 const MONTH_HOURS = 13;
@@ -44,9 +48,9 @@ export default function ScheduleViewScreen() {
           handleNextWeek={handleNextWeek}
         />
         <ScheduleStatusLegend
-          minSessionHours={1}
-          weeklyMaxHours={13}
-          monthlyTargetHours={27}
+          minSessionHours={MIN_SESSION_HOURS}
+          weeklyMaxHours={MAX_WEEK_HOURS}
+          monthlyTargetHours={MAX_MONTH_HOURS}
         />
       </div>
       <div className="flex flex-col gap-2">


### PR DESCRIPTION
## 📌 Related Issues

- close #37 

## 📄 Tasks

- 근로시간 신청 화면 UI 구현
schedule-apply/index.tsx
신청/삭제 시간 카드, 변경 슬롯 리스트, 주차 총 시간, 월 전체 시간 카드 추가
weekTotalTimeAfterApply, monthTotalTimeAfterApply 계산 추가
저장 버튼 disabled 조건 추가

- 선택한 변경 슬롯 리스트 공통 컴포넌트 추가
schedule-change-item/index.tsx
add/delete 아이콘과 시간 라벨 표시

- WorkingHoursCard 확장
working-hours-card/index.tsx
maxHours, progress bar, overflow 색상 처리 추가

- 시간 계산 유틸 보강
utils/index.ts
주차 날짜 기준 합산용 getSlotTimesTotalHoursOnWeek 추가
관련 테스트 추가

- 수정 신청 화면도 공통 변경 리스트/카드 스타일에 맞게 정리
schedule-edit/index.tsx

## 📷 Screenshot

<img width="462" height="815" alt="image" src="https://github.com/user-attachments/assets/2f827512-eaf3-41b8-9a1a-22e373fcdb89" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 변경 내역 목록 컴포넌트 추가(추가/삭제 항목 표시)
  * 주간 단위 슬롯 합산 유틸 추가
* **버그 수정**
  * 오버플로우 상태에서 근무 시간 색상 표시 오류 수정
* **개선 사항**
  * 신청 화면 레이아웃 확장: 상태 범례·근무시간 카드·변경 목록 통합
  * 근무시간 카드 프로그레스바 오버플로우 시 색상 개선
* **테스트**
  * 주간 합산 유틸 동작 검증용 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->