### PR TITLE
[Refactor/#51] 모달 컴포넌트 수정

### DIFF
--- a/src/components/ui/modal/actions.ts
+++ b/src/components/ui/modal/actions.ts
@@ -1,0 +1,39 @@
+export interface ModalActionsOptions {
+  confirmText?: string;
+  onConfirmClick?: () => void;
+  cancelText?: string;
+  onCancelClick?: () => void;
+}
+
+export interface ModalAction {
+  key: "cancel" | "confirm";
+  text: string;
+  onClick?: () => void;
+}
+
+export function getModalActions({
+  cancelText,
+  onCancelClick,
+  confirmText,
+  onConfirmClick,
+}: ModalActionsOptions): ModalAction[] {
+  const actions: ModalAction[] = [];
+
+  if (cancelText) {
+    actions.push({
+      key: "cancel",
+      text: cancelText,
+      onClick: onCancelClick,
+    });
+  }
+
+  if (confirmText) {
+    actions.push({
+      key: "confirm",
+      text: confirmText,
+      onClick: onConfirmClick,
+    });
+  }
+
+  return actions;
+}

--- a/src/components/ui/modal/index.tsx
+++ b/src/components/ui/modal/index.tsx
@@ -2,35 +2,50 @@ import type { HTMLAttributes, ReactNode } from "react";
 
 import { cn } from "@/lib/utils";
 
+import { getModalActions } from "./actions";
+
 interface ModalProps
   extends Omit<HTMLAttributes<HTMLDivElement>, "children" | "title"> {
   open?: boolean;
   title?: ReactNode;
   children?: ReactNode;
-  buttonText?: string;
-  onButtonClick?: () => void;
+  confirmText?: string;
+  onConfirmClick?: () => void;
+  cancelText?: string;
+  onCancelClick?: () => void;
   panelClassName?: string;
   titleClassName?: string;
   contentClassName?: string;
-  buttonClassName?: string;
+  confirmButtonClassName?: string;
+  cancelButtonClassName?: string;
 }
 
 export default function Modal({
   open = true,
   title,
   children,
-  buttonText = "확인",
-  onButtonClick,
+  confirmText,
+  onConfirmClick,
+  cancelText,
+  onCancelClick,
   className,
   panelClassName,
   titleClassName,
   contentClassName,
-  buttonClassName,
+  confirmButtonClassName,
+  cancelButtonClassName,
   ...props
 }: ModalProps) {
   if (!open) {
     return null;
   }
+
+  const actions = getModalActions({
+    cancelText,
+    onCancelClick,
+    confirmText,
+    onConfirmClick,
+  });
 
   return (
     <div
@@ -44,20 +59,20 @@ export default function Modal({
     >
       <section
         className={cn(
-          "flex max-h-103 w-76.5 max-w-full flex-col overflow-hidden rounded-[10px] bg-white opacity-100 shadow-[0_4px_20px_0_#00000040]",
+          "flex max-h-103 max-w-80 flex-col items-center justify-center overflow-hidden rounded-[10px] bg-white text-center opacity-100 shadow-[0_4px_20px_0_#00000040]",
           panelClassName,
         )}
       >
         <div
           className={cn(
-            "modal-scrollbar mr-4 min-h-0 flex-1 overflow-y-auto px-6 py-7 text-[#000000]",
+            "modal-scrollbar flex min-h-0 flex-1 flex-col gap-7 overflow-y-auto px-6 py-7 text-sm text-[#000000]",
             contentClassName,
           )}
         >
           {title ? (
             <h2
               className={cn(
-                "pl-6 text-center align-middle text-xl leading-none font-bold tracking-[0.21px]",
+                "text-center align-middle text-base leading-none font-bold tracking-[0.21px]",
                 titleClassName,
               )}
             >
@@ -68,16 +83,26 @@ export default function Modal({
           {children}
         </div>
 
-        <button
-          type="button"
-          className={cn(
-            "flex h-14 min-h-14 w-full shrink-0 cursor-pointer items-center justify-center bg-[#2076FF] text-base leading-6 font-normal tracking-[0.24px] text-white",
-            buttonClassName,
-          )}
-          onClick={onButtonClick}
-        >
-          {buttonText}
-        </button>
+        {actions.length > 0 ? (
+          <div className="flex w-full shrink-0">
+            {actions.map((action) => (
+              <button
+                key={action.key}
+                type="button"
+                className={cn(
+                  "flex h-10 flex-1 cursor-pointer items-center justify-center text-sm leading-6 font-normal tracking-[0.24px] text-white",
+                  action.key === "confirm" ? "bg-[#2076FF]" : "bg-[#CBD1DA]",
+                  action.key === "confirm"
+                    ? confirmButtonClassName
+                    : cancelButtonClassName,
+                )}
+                onClick={action.onClick}
+              >
+                {action.text}
+              </button>
+            ))}
+          </div>
+        ) : null}
       </section>
     </div>
   );

--- a/src/screens/schedule/schedule-edit/index.tsx
+++ b/src/screens/schedule/schedule-edit/index.tsx
@@ -19,7 +19,7 @@ import {
 } from "@/features/schedule";
 import { SLOT_REQUEST_EDIT_CLASS_NAME } from "@/features/schedule/constants";
 import { getMonthWeekOfDate, shiftDateByWeeks } from "@/lib/date-formatter";
-import { Button } from "@/components/ui";
+import { Button, Modal } from "@/components/ui";
 
 // TODO: 추후 서버에서 받아올 값
 const MIN_SESSION_HOURS = 1;
@@ -40,6 +40,7 @@ export default function ScheduleEditScreen() {
     addSlots: [],
   });
   const [reason, setReason] = useState("");
+  const [isModalOpen, setIsModalOpen] = useState(false);
 
   const { year, month, week } = getMonthWeekOfDate(selectedDate);
   const currentMonthWeek = getMonthWeekOfDate(today);
@@ -105,6 +106,13 @@ export default function ScheduleEditScreen() {
         getAbleToAddHours(getSlotTimesTotalHours(currentPayload.deleteSlots)),
       ),
     );
+  };
+
+  const handleOpenModal = () => {
+    setIsModalOpen(true);
+  };
+  const handleCloseModal = () => {
+    setIsModalOpen(false);
   };
 
   return (
@@ -198,16 +206,24 @@ export default function ScheduleEditScreen() {
       </div>
 
       {/* TODO: 서버 연동 시 요청 바디 고려 */}
-      <Button
-        size="lg"
-        onClick={() => {
+      <Button size="lg" onClick={handleOpenModal} disabled={buttonDisabled}>
+        신청하기
+      </Button>
+
+      <Modal
+        open={isModalOpen}
+        title="수정 요청을 제출하시겠습니까?"
+        confirmText="제출하기"
+        onConfirmClick={() => {
           console.log("변경 시간 : ", getMergedApplyPayload(editPayload));
           console.log("변경 사유 : ", reason);
         }}
-        disabled={buttonDisabled}
+        cancelText="취소"
+        onCancelClick={handleCloseModal}
       >
-        신청하기
-      </Button>
+        현재 월 근무시간과 상이합니다. 해당 내용은 관리자에게 전달되며, 반려될
+        수 있습니다.
+      </Modal>
     </div>
   );
 }


### PR DESCRIPTION
## 📌 Related Issues

- close #51 

## 📄 Tasks

- 모달 컴포넌트를 아래와 같이 수정했습니다.
1. 하단 버튼이 아예 없거나 하나 또는 두개가 올 수 있습니다. 
  - 두개인 경우, 취소와 확인
  - 하나인 경우, 확인
  - 버튼 높이 h-10으로 수정
  - 버튼 내부 폰트 크기 수정
2. 타이틀과 children의 폰크 크기 수정
3. 모달 내부 정렬 방식 수정

보시고 괜찮으시면 수정한데로 진행하겠습니다!

TODO: 근로시간 관련 모달 적용

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 스케줄 신청 시 확인 모달이 추가되었습니다. 사용자가 신청 전에 변경 사항을 검토하고 확인할 수 있습니다.

* **Improvements**
  * 모달 컴포넌트가 확인/취소 두 개의 액션 버튼을 지원하도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->