### PR TITLE
feat: 마이페이지 로그아웃 탈퇴 alert, toast 추가

### DIFF
--- a/src/features/my-page/components/menu-card/index.tsx
+++ b/src/features/my-page/components/menu-card/index.tsx
@@ -9,9 +9,14 @@ interface MenuItemProps {
   href?: string;
   iconSrc: string;
   label: string;
+  onClick?: () => void;
 }
 
-function MenuItem({ href, iconSrc, label }: MenuItemProps) {
+interface MenuCardProps {
+  onLogout?: () => void;
+}
+
+function MenuItem({ href, iconSrc, label, onClick }: MenuItemProps) {
   const content = (
     <>
       <span className="flex min-w-0 items-center gap-2">
@@ -52,13 +57,13 @@ function MenuItem({ href, iconSrc, label }: MenuItemProps) {
   }
 
   return (
-    <button className={className} type="button">
+    <button className={className} type="button" onClick={onClick}>
       {content}
     </button>
   );
 }
 
-export default function MenuCard() {
+export default function MenuCard({ onLogout }: MenuCardProps) {
   return (
     <section className="overflow-hidden rounded-[20px] border-[0.5px] border-[#DDE3EF] bg-white shadow-[0_2px_8px_0_#F3F2F2]">
       <MenuItem
@@ -67,7 +72,7 @@ export default function MenuCard() {
         label="근무시간 신청기록"
       />
       <div className="border-t-[0.5px] border-[#DDE3EF]" />
-      <MenuItem iconSrc={logoutIcon} label="로그아웃" />
+      <MenuItem iconSrc={logoutIcon} label="로그아웃" onClick={onLogout} />
     </section>
   );
 }

--- a/src/features/my-page/components/worktime-history-list/index.tsx
+++ b/src/features/my-page/components/worktime-history-list/index.tsx
@@ -63,20 +63,20 @@ export default function WorktimeHistoryList({
               </div>
 
               <ul className="mt-3 flex flex-col gap-1">
-                {getHistorySlots(history).map((change, changeIndex) => (
-                  <li
-                    className="flex items-center gap-1.5 text-[10px] leading-4.5 font-medium text-[#1A2236]"
-                    key={`${change.changeTypeCode}-${change.start}-${change.end}-${changeIndex}`}
-                  >
-                    <Image
-                      alt=""
-                      aria-hidden="true"
-                      className="shrink-0"
-                      height={5}
-                      src={changeTypeIcons[change.changeTypeCode]}
-                      unoptimized
-                      width={5}
-                    />
+              {getHistorySlots(history).map((change, changeIndex) => (
+                <li
+                  className="flex items-center gap-1.5 text-[10px] leading-4.5 font-medium text-[#1A2236]"
+                  key={`${change.changeTypeCode ?? "CR01"}-${change.start}-${change.end}-${changeIndex}`}
+                >
+                  <Image
+                    alt=""
+                    aria-hidden="true"
+                    className="shrink-0"
+                    height={5}
+                    src={changeTypeIcons[change.changeTypeCode ?? "CR01"]}
+                    unoptimized
+                    width={5}
+                  />
                     <span>{formatScheduleChangeHistorySlot(change)}</span>
                   </li>
                 ))}

--- a/src/screens/my-page/index.tsx
+++ b/src/screens/my-page/index.tsx
@@ -1,3 +1,8 @@
+"use client";
+
+import { useState } from "react";
+
+import { Alert, Toast } from "@/components/ui";
 import {
   MenuCard,
   MY_PAGE_USER,
@@ -7,6 +12,25 @@ import {
 } from "@/features/my-page";
 
 export default function MyPageScreen() {
+  const [openAlert, setOpenAlert] = useState<"logout" | "withdraw" | null>(
+    null,
+  );
+  const [toastMessage, setToastMessage] = useState("");
+
+  const closeAlert = () => {
+    setOpenAlert(null);
+  };
+
+  const handleLogoutConfirm = () => {
+    closeAlert();
+    setToastMessage("로그아웃되었습니다.");
+  };
+
+  const handleWithdrawConfirm = () => {
+    closeAlert();
+    setToastMessage("회원 탈퇴되었습니다.");
+  };
+
   return (
     <section className="min-h-screen w-full bg-white px-4 pt-10.75 pb-20">
       <h1 className="px-3 text-[20px] leading-[19.5px] font-bold text-[#1A2236]">
@@ -35,15 +59,38 @@ export default function MyPageScreen() {
       </div>
 
       <div className="mt-6">
-        <MenuCard />
+        <MenuCard onLogout={() => setOpenAlert("logout")} />
       </div>
 
       <button
         className="mx-auto mt-7 block cursor-pointer text-[10px] leading-4.5 font-medium text-[#FD7171] underline underline-offset-2"
         type="button"
+        onClick={() => setOpenAlert("withdraw")}
       >
         회원 탈퇴
       </button>
+
+      <Alert
+        open={openAlert === "logout"}
+        title="로그아웃"
+        message="로그아웃 하시겠습니까?"
+        onCancel={closeAlert}
+        onConfirm={handleLogoutConfirm}
+      />
+      <Alert
+        open={openAlert === "withdraw"}
+        title="탈퇴하시겠습니까?"
+        message={"탈퇴 버튼 선택 시, 계정은 삭제되며\n복구되지 않습니다."}
+        confirmText="탈퇴"
+        onCancel={closeAlert}
+        onConfirm={handleWithdrawConfirm}
+        confirmButtonClassName="bg-[#FD7171]"
+      />
+      <Toast
+        open={toastMessage.length > 0}
+        message={toastMessage}
+        onDismiss={() => setToastMessage("")}
+      />
     </section>
   );
 }


### PR DESCRIPTION
## 📌 Related Issues

#59

- close #59

## 📄 Tasks

- 마이페이지 로그아웃, 회원탈퇴 alert, toast 연결 

## 📷 Screenshot
<img width="585" height="853" alt="무제" src="https://github.com/user-attachments/assets/40a8d467-c476-44c4-a0c5-e7cef868130a" />

<img width="542" height="901" alt="무제1" src="https://github.com/user-attachments/assets/7e5a392b-4bd9-4ee4-9ada-cd35ea2084a5" />
<img width="582" height="825" alt="무제2" src="https://github.com/user-attachments/assets/453484bf-ad51-4c0d-b6e1-4110aa564dc2" />
<img width="485" height="802" alt="무제3" src="https://github.com/user-attachments/assets/5fd66a99-ce65-43e7-a2de-e1f4ee3470b6" />
